### PR TITLE
#41 disable initial magnification

### DIFF
--- a/lib/src/crop.dart
+++ b/lib/src/crop.dart
@@ -325,6 +325,9 @@ class CropState extends State<Crop> with TickerProviderStateMixin, Drag {
           viewWidth,
           viewHeight,
         );
+        // disable initial magnification
+        _scale = _minimumScale ?? 1.0;
+        _view = _getViewInBoundaries(_scale);
       });
     });
 


### PR DESCRIPTION
By adjusting the initial scale, loaded image will fit the crop box instead of the screen.